### PR TITLE
Fixing runtime version

### DIFF
--- a/sfcli/SmartFace.Cli/SmartFace.Cli.csproj
+++ b/sfcli/SmartFace.Cli/SmartFace.Cli.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <RootNamespace>SmartFace.Cli</RootNamespace>
         <Version>4.0.0</Version>
         <AssemblyName>sfcli</AssemblyName>


### PR DESCRIPTION
Removed TargetLatestRuntimePatch csproj attribute, so that published binaries run on older patches of dotnet runtime. This is needed because we build with newest patch of SDK, but the runtime images potentially have older patch of runtime