### PR TITLE
Use connection pooling

### DIFF
--- a/sf-docker/.env
+++ b/sf-docker/.env
@@ -6,9 +6,9 @@ RabbitMQ__Port=5672
 
 # Database config
 #Database__DbEngine=MsSql
-#ConnectionStrings__CoreDbContext=Server=mssql;Database=SmartFace;User ID=sa;Password=Test1234;Pooling=False;MultipleActiveResultSets=False;trustservercertificate=true;
+#ConnectionStrings__CoreDbContext=Server=mssql;Database=SmartFace;User ID=sa;Password=Test1234;TrustServerCertificate=true;
 Database__DbEngine=PgSql
-ConnectionStrings__CoreDbContext=Server=pgsql;Database=smartface;Username=postgres;Password=Test1234;Pooling=False;Trust Server Certificate=true;
+ConnectionStrings__CoreDbContext=Server=pgsql;Database=smartface;Username=postgres;Password=Test1234;Trust Server Certificate=true;
 
 # S3 config
 S3Bucket__Endpoint=http://minio:9000

--- a/sf-docker/run-jetson.sh
+++ b/sf-docker/run-jetson.sh
@@ -28,7 +28,7 @@ echo $REGISTRY
 # create SmartFace database in PgSql
 docker exec pgsql psql -U postgres -c "CREATE DATABASE smartface" || true
 # run database migration to current version
-docker run --rm --name admin_migration --network sf-network ${REGISTRY}sf-jetson-admin:${VERSION} run-migration -p 5 -c "Server=pgsql;Database=smartface;Username=postgres;Password=Test1234;Pooling=False;Trust Server Certificate=true;" -dbe PgSql
+docker run --rm --name admin_migration --network sf-network ${REGISTRY}sf-jetson-admin:${VERSION} run-migration -p 5 -c "Server=pgsql;Database=smartface;Username=postgres;Password=Test1234;Trust Server Certificate=true;" -dbe PgSql
 
 # finally start SF images
 docker-compose -f jetson-docker-compose.yml up -d --force-recreate

--- a/sf-docker/run.sh
+++ b/sf-docker/run.sh
@@ -38,7 +38,7 @@ elif [[ "$DB_ENGINE" == "PgSql" ]]; then
     # create SmartFace database in PgSql
     docker exec pgsql psql -U postgres -c "CREATE DATABASE smartface" || true
     # run database migration to current version
-    docker run --rm --name admin_migration --network sf-network ${REGISTRY}sf-admin:${VERSION} run-migration -p 5 -c "Server=pgsql;Database=smartface;Username=postgres;Password=Test1234;Pooling=False;Trust Server Certificate=true;" -dbe $DB_ENGINE
+    docker run --rm --name admin_migration --network sf-network ${REGISTRY}sf-admin:${VERSION} run-migration -p 5 -c "Server=pgsql;Database=smartface;Username=postgres;Password=Test1234;Trust Server Certificate=true;" -dbe $DB_ENGINE
 else 
     echo "Unknown DB engine: ${DB_ENGINE}!"
     exit 1


### PR DESCRIPTION
`Pooling` is a good thing. We should enable it by default.
`MultipleActiveResultSets` is `false` by default ([see here](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring?view=dotnet-plat-ext-5.0)), we don't need to set it explicitly.
[minor] `TrustServerCertificate` is the correct syntax.