### PR TITLE
Docker Compose v2 compatibility

### DIFF
--- a/sf-docker/.env
+++ b/sf-docker/.env
@@ -13,9 +13,6 @@ ConnectionStrings__CoreDbContext=Server=pgsql;Database=smartface;Username=postgr
 # S3 config
 S3Bucket__Endpoint=http://minio:9000
 
-# SF config
-AppSettings__Log-RollingFile-Enabled=false
-
 # Set true when a Jaeger tracing is required
 AppSettings__USE_JAEGER_APP_SETTINGS=false
 

--- a/sf-docker/cloud-matcher-docker-compose.yml
+++ b/sf-docker/cloud-matcher-docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -22,7 +22,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -38,7 +38,7 @@ services:
       - RabbitMQ__Port
       - Database__DbEngine
       - ConnectionStrings__CoreDbContext
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -59,7 +59,7 @@ services:
       - ConnectionStrings__CoreDbContext
       - Hosting__Host
       - Hosting__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint

--- a/sf-docker/docker-compose.yml
+++ b/sf-docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -35,7 +35,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -58,7 +58,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -84,7 +84,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -110,7 +110,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -136,7 +136,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -162,7 +162,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -187,7 +187,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -214,7 +214,7 @@ services:
       - Database__DbEngine
       - Hosting__Host
       - Hosting__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -235,7 +235,7 @@ services:
       - Database__DbEngine
       - Hosting__Host
       - Hosting__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - AppSettings__Log_RabbitMq_Enabled
@@ -256,7 +256,7 @@ services:
       - Database__DbEngine
       - Hosting__Host
       - Hosting__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -274,7 +274,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       # - Gpu__GpuEnabled=true
@@ -293,7 +293,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       # - Gpu__GpuEnabled=true
@@ -312,7 +312,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       # - Gpu__GpuEnabled=true
@@ -333,7 +333,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -350,7 +350,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -365,7 +365,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       # - Gpu__GpuEnabled=true
@@ -386,7 +386,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -405,7 +405,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -422,7 +422,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -437,7 +437,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:

--- a/sf-docker/jetson-docker-compose.yml
+++ b/sf-docker/jetson-docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -38,7 +38,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -63,7 +63,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -90,7 +90,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -116,7 +116,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -144,7 +144,7 @@ services:
       - Database__DbEngine
       - Hosting__Host
       - Hosting__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -166,7 +166,7 @@ services:
       - Database__DbEngine
       - Hosting__Host
       - Hosting__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - AppSettings__Log_RabbitMq_Enabled
@@ -188,7 +188,7 @@ services:
       - Database__DbEngine
       - Hosting__Host
       - Hosting__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -208,7 +208,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -225,7 +225,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - Gpu__GpuEnabled=true
@@ -245,7 +245,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -262,7 +262,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - Gpu__GpuEnabled=true
@@ -282,7 +282,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -299,7 +299,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - Gpu__GpuEnabled=true
@@ -321,7 +321,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -340,7 +340,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -357,7 +357,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:
@@ -374,7 +374,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - Gpu__GpuEnabled=true
@@ -396,7 +396,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -417,7 +417,7 @@ services:
       - RabbitMQ__Port
       - ConnectionStrings__CoreDbContext
       - Database__DbEngine
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
       - S3Bucket__Endpoint
@@ -435,7 +435,7 @@ services:
       - RabbitMQ__Username
       - RabbitMQ__Password
       - RabbitMQ__Port
-      - AppSettings__Log-RollingFile-Enabled
+      - AppSettings__Log-RollingFile-Enabled=false
       - AppSettings__USE_JAEGER_APP_SETTINGS
       - JAEGER_AGENT_HOST
     volumes:

--- a/sf-docker/run-cloud-matcher.sh
+++ b/sf-docker/run-cloud-matcher.sh
@@ -4,16 +4,33 @@ set -x
 set -e
 
 if [ ! -f iengine.lic ]; then
-    echo "License file not found. Please make sure that the license file is present in the current directory."
+    echo "License file not found. Please make sure that the license file is present in the current directory." >&2
     exit 1
 fi
+
+COMPOSE_COMMAND="docker compose"
+
+set +e
+
+$COMPOSE_COMMAND version
+
+if [ $? -ne 0 ]; then
+    COMPOSE_COMMAND="docker-compose"
+    $COMPOSE_COMMAND version
+    if [ $? -ne 0 ]; then
+        echo "No compose command found. Please install docker compose" >&2
+        exit 1
+    fi
+fi
+
+set -e
 
 # sf-network is used so that sf-dependencies and sf containers can communicate
 # this can fail if the network already exists, but we don't mind that
 docker network create sf-network || true
 
 # start dependencies of SF - MsSql, RMQ and minio
-docker-compose -f sf_dependencies/docker-compose.yml up -d
+$COMPOSE_COMMAND -f sf_dependencies/docker-compose.yml up -d
 
 # sleep to wait for the dependencies to start up
 sleep 10
@@ -29,4 +46,4 @@ REGISTRY=$(grep -E ^REGISTRY .env | cut -d '=' -f2 | cut -d$'\r' -f1)
 docker run --rm --name admin_migration --network sf-network ${REGISTRY}sf-admin:${VERSION} run-migration -p 5 -c "Server=mssql;Database=SmartFace;User ID=sa;Password=Test1234;"
 
 # finally start SF images
-docker-compose -f cloud-matcher-docker-compose.yml up -d
+$COMPOSE_COMMAND -f cloud-matcher-docker-compose.yml up -d

--- a/sf-docker/run-jetson.sh
+++ b/sf-docker/run-jetson.sh
@@ -4,16 +4,33 @@ set -x
 set -e
 
 if [ ! -f iengine.lic ]; then
-    echo "License file not found. Please make sure that the license file is present in the current directory."
+    echo "License file not found. Please make sure that the license file is present in the current directory." >&2
     exit 1
 fi
+
+COMPOSE_COMMAND="docker compose"
+
+set +e
+
+$COMPOSE_COMMAND version
+
+if [ $? -ne 0 ]; then
+    COMPOSE_COMMAND="docker-compose"
+    $COMPOSE_COMMAND version
+    if [ $? -ne 0 ]; then
+        echo "No compose command found. Please install docker compose" >&2
+        exit 1
+    fi
+fi
+
+set -e
 
 # sf-network is used so that sf-dependencies and sf containers can communicate
 # this can fail if the network already exists, but we don't mind that
 docker network create sf-network || true
 
 # start dependencies of SF - MsSql, RMQ and minio
-docker-compose -f sf_dependencies/docker-compose.yml up -d
+$COMPOSE_COMMAND -f sf_dependencies/docker-compose.yml up -d
 
 # sleep to wait for the dependencies to start up
 sleep 10
@@ -31,4 +48,4 @@ docker exec pgsql psql -U postgres -c "CREATE DATABASE smartface" || true
 docker run --rm --name admin_migration --network sf-network ${REGISTRY}sf-jetson-admin:${VERSION} run-migration -p 5 -c "Server=pgsql;Database=smartface;Username=postgres;Password=Test1234;Trust Server Certificate=true;" -dbe PgSql
 
 # finally start SF images
-docker-compose -f jetson-docker-compose.yml up -d --force-recreate
+$COMPOSE_COMMAND -f jetson-docker-compose.yml up -d --force-recreate


### PR DESCRIPTION
The run scripts should now properly run with Docker compose v2, even when installed as a docker cli plugin