### PR TITLE
Added config to API for static preview port

### DIFF
--- a/sf-docker/.env
+++ b/sf-docker/.env
@@ -26,6 +26,9 @@ JAEGER_AGENT_HOST=jaeger
 Hosting__Host=http://0.0.0.0
 Hosting__Port=80
 
+# we override the default generation of preview ports for camera in favor of static configuration
+CameraDefaults__PreviewPort=30000
+
 # Using NoSql database
 NoSqlDataStorageDisabled=false
 

--- a/sf-docker/docker-compose.yml
+++ b/sf-docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     container_name: SFCam1
     command: --serviceName SFCam1
     ports:
-      - 30001:30001
+      - 30001:${CameraDefaults__PreviewPort}
     restart: unless-stopped
     environment:
       - RabbitMQ__Hostname
@@ -75,7 +75,7 @@ services:
     container_name: SFCam2
     command: --serviceName SFCam2
     ports:
-      - 30002:30002
+      - 30002:${CameraDefaults__PreviewPort}
     restart: unless-stopped
     environment:
       - RabbitMQ__Hostname
@@ -101,7 +101,7 @@ services:
     container_name: SFCam3
     command: --serviceName SFCam3
     ports:
-      - 30003:30003
+      - 30003:${CameraDefaults__PreviewPort}
     restart: unless-stopped
     environment:
       - RabbitMQ__Hostname
@@ -127,7 +127,7 @@ services:
     container_name: SFCam4
     command: --serviceName SFCam4
     ports:
-      - 30004:30004
+      - 30004:${CameraDefaults__PreviewPort}
     restart: unless-stopped
     environment:
       - RabbitMQ__Hostname
@@ -153,7 +153,7 @@ services:
     container_name: SFCam5
     command: --serviceName SFCam5
     ports:
-      - 30005:30005
+      - 30005:${CameraDefaults__PreviewPort}
     restart: unless-stopped
     environment:
       - RabbitMQ__Hostname
@@ -220,6 +220,7 @@ services:
       - S3Bucket__Endpoint
       - NoSqlDataStorageDisabled
       - Metrics__PROMETHEUS_METRIC_SERVER_HOSTNAME
+      - CameraDefaults__PreviewPort
     volumes:
       - "./iengine.lic:/etc/innovatrics/iengine.lic"
 

--- a/sf-docker/jetson-docker-compose.yml
+++ b/sf-docker/jetson-docker-compose.yml
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
     command: --serviceName SFCam1
     ports:
-      - 30001:30001
+      - 30001:${CameraDefaults__PreviewPort}
     environment:
       - RabbitMQ__Hostname
       - RabbitMQ__Username
@@ -82,7 +82,7 @@ services:
     restart: unless-stopped
     command: --serviceName SFCam2
     ports:
-      - 30002:30002
+      - 30002:${CameraDefaults__PreviewPort}
     environment:
       - RabbitMQ__Hostname
       - RabbitMQ__Username
@@ -150,6 +150,7 @@ services:
       - S3Bucket__Endpoint
       - NoSqlDataStorageDisabled
       - Metrics__PROMETHEUS_METRIC_SERVER_HOSTNAME
+      - CameraDefaults__PreviewPort
     volumes:
       - "./iengine.lic:/etc/innovatrics/iengine.lic"
     runtime: nvidia


### PR DESCRIPTION
New camera entities created by configured API service will always use port 30 000 (unless specified otherwise in the API request). This enables easier port forwarding from docker guests to the host