### PR TITLE
VPP-138 Environment variables specified as objects

### DIFF
--- a/sf-observability/docker-compose.yml
+++ b/sf-observability/docker-compose.yml
@@ -57,9 +57,9 @@ services:
       - ./configuration/grafana/dashboards:/etc/grafana/provisioning/dashboards
       - grafana_data:/var/lib/grafana
     environment:
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: true
     networks:
       observability:
     restart: unless-stopped
@@ -102,8 +102,8 @@ services:
         export HOSTNAME=$$(cat /etc/hostname)
         /bin/alloy run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data alloy_config
     environment:
-      - LOKI_URL=http://loki:3100/loki/api/v1/push
-      - PROMETHEUS_URL=http://prometheus:9090/api/v1/write
+      LOKI_URL: http://loki:3100/loki/api/v1/push
+      PROMETHEUS_URL: http://prometheus:9090/api/v1/write
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /etc/hostname:/etc/hostname:ro


### PR DESCRIPTION
Environment variables in sf-observability docker compose are specified as objects (not as key value array) so that it is easier to change them in automated deployments.