### PR TITLE
Update to version 4.40.2

### DIFF
--- a/LFIS/.env
+++ b/LFIS/.env
@@ -60,7 +60,7 @@ GstPipelineTemplate_Jetson=uridecodebin uri={0} source::latency=0 ! queue max-si
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 
 # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.32.0
 

--- a/all-in-one/.env
+++ b/all-in-one/.env
@@ -59,7 +59,7 @@ GstPipelineTemplate=uridecodebin uri={0} source::latency=0 ! queue max-size-buff
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 
 # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.32.0
 

--- a/special/package-easy-door-opening/.env
+++ b/special/package-easy-door-opening/.env
@@ -58,7 +58,7 @@ GstPipelineTemplate=uridecodebin uri={0} source::latency=0 ! queue max-size-buff
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 #
 # # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.32.0
 

--- a/special/package-event-security-monitoring/central-node/.env
+++ b/special/package-event-security-monitoring/central-node/.env
@@ -54,7 +54,7 @@ GstPipelineTemplate=uridecodebin uri={0} source::latency=0 ! queue max-size-buff
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 
 # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.30.1
 

--- a/special/package-event-security-monitoring/local-node/.env
+++ b/special/package-event-security-monitoring/local-node/.env
@@ -54,7 +54,7 @@ GstPipelineTemplate=uridecodebin uri={0} source::latency=0 ! queue max-size-buff
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 
 # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.30.1
 

--- a/special/sf-2-sf-synchronization/follower/.env
+++ b/special/sf-2-sf-synchronization/follower/.env
@@ -54,7 +54,7 @@ GstPipelineTemplate=uridecodebin uri={0} source::latency=0 ! queue max-size-buff
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 
 # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.32.0
 

--- a/special/sf-2-sf-synchronization/leader/.env
+++ b/special/sf-2-sf-synchronization/leader/.env
@@ -54,7 +54,7 @@ GstPipelineTemplate=uridecodebin uri={0} source::latency=0 ! queue max-size-buff
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 
 # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.32.0
 

--- a/special/sf-with-keycloak/sf-server/.env
+++ b/special/sf-with-keycloak/sf-server/.env
@@ -54,7 +54,7 @@ GstPipelineTemplate=uridecodebin uri={0} source::latency=0 ! queue max-size-buff
 REGISTRY=registry.gitlab.com/innovatrics/smartface/
 
 # Version
-SF_VERSION=v5_4.40.1
+SF_VERSION=v5_4.40.2
 AC_VERSION=v5_1.14.0
 SFS_VERSION=v5_1.32.0
 


### PR DESCRIPTION
Version 4.40.2 adds support to linking faces with pedestrians also for Edge stream inputs (as it was already present in camera inputs)

No other changes are present in this version.