### PR TITLE
Fix SmartFace Station core API hostname in all-in-one env

### DIFF
--- a/all-in-one/.env.sfstation
+++ b/all-in-one/.env.sfstation
@@ -6,7 +6,7 @@ PORT=8000
 
 # Full addresses to SmartFace Server APIs
 # CORE API example: http://[sf-server-host]:[port]/api/v1
-CORE_API_ROOT=http://SFApi:80/api/v1
+CORE_API_ROOT=http://api:80/api/v1
 
 # Full address to SmartFace Server GraphQL APIs
 GRAPHQL_ROOT=http://SFGraphQLApi:80/graphql


### PR DESCRIPTION
The API calls were failing with the following error: 
`[GraphQL] request to http://sfapi/api/v1/Setup/DataStorage/Video failed, reason: getaddrinfo ENOTFOUND sfapi` 
due to the wrong endpoint that was provided.